### PR TITLE
Have CoreOS make a hosts file by default

### DIFF
--- a/dcos.tf
+++ b/dcos.tf
@@ -11,7 +11,7 @@ resource "packet_device" "dcos_bootstrap" {
     user = "core"
     private_key = "${var.dcos_ssh_key_path}"
   }
-  user_data     = "#cloud-config\n\nssh_authorized_keys:\n  - \"${file("${var.dcos_ssh_public_key_path}")}\"\n"
+  user_data     = "#cloud-config\n\nmanage_etc_hosts: \"localhost\"\nssh_authorized_keys:\n  - \"${file("${var.dcos_ssh_public_key_path}")}\"\n"
   facility      = "${var.packet_facility}"
   project_id    = "${var.packet_project_id}"
   billing_cycle = "hourly"
@@ -58,7 +58,7 @@ resource "packet_device" "dcos_master" {
   plan             = "${var.packet_master_type}"
 
   count         = "${var.dcos_master_count}"
-  user_data     = "#cloud-config\n\nssh_authorized_keys:\n  - \"${file("${var.dcos_ssh_public_key_path}")}\"\n"
+  user_data     = "#cloud-config\n\nmanage_etc_hosts: \"localhost\"\nssh_authorized_keys:\n  - \"${file("${var.dcos_ssh_public_key_path}")}\"\n"
   facility      = "${var.packet_facility}"
   project_id    = "${var.packet_project_id}"
   billing_cycle = "hourly"
@@ -91,7 +91,7 @@ resource "packet_device" "dcos_agent" {
   plan             = "${var.packet_agent_type}"
 
   count         = "${var.dcos_agent_count}"
-  user_data     = "#cloud-config\n\nssh_authorized_keys:\n  - \"${file("${var.dcos_ssh_public_key_path}")}\"\n"
+  user_data     = "#cloud-config\n\nmanage_etc_hosts: \"localhost\"\nssh_authorized_keys:\n  - \"${file("${var.dcos_ssh_public_key_path}")}\"\n"
   facility      = "${var.packet_facility}"
   project_id    = "${var.packet_project_id}"
   billing_cycle = "hourly"  
@@ -119,7 +119,7 @@ resource "packet_device" "dcos_public_agent" {
   plan             = "${var.packet_agent_type}"
 
   count         = "${var.dcos_public_agent_count}"
-  user_data     = "#cloud-config\n\nssh_authorized_keys:\n  - \"${file("${var.dcos_ssh_public_key_path}")}\"\n"
+  user_data     = "#cloud-config\n\nmanage_etc_hosts: \"localhost\"\nssh_authorized_keys:\n  - \"${file("${var.dcos_ssh_public_key_path}")}\"\n"
   facility      = "${var.packet_facility}"
   project_id    = "${var.packet_project_id}"
   billing_cycle = "hourly"  


### PR DESCRIPTION
CoreOS by default does not generate a `/etc/hosts` file. This causes a problem when DNS is not reachable and so certain services like Elasticsearch will fail. This makes and adds
```
127.0.0.1 hostname
```
in the `/etc/hosts` file.