### PR TITLE
Remove duplicate output resulting in an error

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -13,6 +13,3 @@ output "bootstrap-ip" {
 output "Use this link to access DCOS" {
   value = "http://${packet_device.dcos_master.network.0.address}/"
 }
-output "Use this link to access DCOS" {
-  value = "http://${packet_device.dcos_master.0.network.0.address}/"
-}


### PR DESCRIPTION
The file contains a duplicate entry containing the same output. 

When trying to to execute a command e.g. 

`terraform plan` 

the execution failt with the following error

module root: 1 error(s) occurred:
- Use this link to access DCOS: duplicate output. output names must be unique.
